### PR TITLE
Moved test to test_image_copy.py

### DIFF
--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import hopper
+from .helper import hopper, skip_unless_feature
 
 
 @pytest.mark.parametrize("mode", ("1", "P", "L", "RGB", "I", "F"))
@@ -42,3 +42,10 @@ def test_copy_zero():
     out = im.copy()
     assert out.mode == im.mode
     assert out.size == im.size
+
+
+@skip_unless_feature("libtiff")
+def test_deepcopy():
+    with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        out = copy.deepcopy(im)
+    assert out.size == (590, 88)

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,5 +1,4 @@
 import warnings
-from copy import deepcopy
 
 import pytest
 
@@ -224,14 +223,6 @@ def test_zero_size():
 def test_load_first():
     with Image.open("Tests/images/g4_orientation_5.tif") as im:
         a = numpy.array(im)
-        assert a.shape == (88, 590)
-
-
-@skip_unless_feature("libtiff")
-def test_load_first_deepcopy():
-    with Image.open("Tests/images/g4_orientation_5.tif") as im:
-        im_deepcopy = deepcopy(im)
-        a = numpy.array(im_deepcopy)
         assert a.shape == (88, 590)
 
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7105

I was able to modify your test to work without NumPy. So I think it belongs in test_image_copy.py, rather than test_numpy.py.